### PR TITLE
Rename packages to match go mod expectations for v2+ modules

### DIFF
--- a/bicache.go
+++ b/bicache.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/jamiealquiza/bicache/sll"
+	"github.com/jamiealquiza/bicache/v2/sll"
 	"github.com/jamiealquiza/tachymeter"
 )
 

--- a/bicache_test.go
+++ b/bicache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jamiealquiza/bicache"
+	"github.com/jamiealquiza/bicache/v2"
 )
 
 func TestNew(t *testing.T) {

--- a/examples/bicache-example/main.go
+++ b/examples/bicache-example/main.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jamiealquiza/bicache"
+	"github.com/jamiealquiza/bicache/v2"
 	"github.com/jamiealquiza/tachymeter"
 )
 

--- a/examples/bicache-loadtest/main.go
+++ b/examples/bicache-loadtest/main.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jamiealquiza/bicache"
+	"github.com/jamiealquiza/bicache/v2"
 	"github.com/jamiealquiza/tachymeter"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/jamiealquiza/bicache
+module github.com/jamiealquiza/bicache/v2
 
 go 1.15
 
 require (
+	github.com/jamiealquiza/bicache v2.0.0+incompatible
 	github.com/jamiealquiza/fnv v1.0.0
 	github.com/jamiealquiza/tachymeter v2.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/jamiealquiza/bicache v1.0.0 h1:WsiPPV5oWP/cYKBFaLkdpMt2Ft/M/Q2kntUGlzM2b1Q=
+github.com/jamiealquiza/bicache v2.0.0+incompatible h1:0V+RlPLr4g9PkC2CZdZg/6NlN6bgdhlqdEsP1Fm6Q8U=
+github.com/jamiealquiza/bicache v2.0.0+incompatible/go.mod h1:xSPiksbz+HyGfZ+2f5KngWsTJex9wUilkK4sIdXDgUM=
 github.com/jamiealquiza/fnv v1.0.0 h1:4NwlkaoZiLhqk008EY5+MTGVPRQZgRG/6B7+jN7ueT8=
 github.com/jamiealquiza/fnv v1.0.0/go.mod h1:iJRnFlvFvZpWKZd+KljYXcyQLasMIKAVuQhx63P4DUk=
 github.com/jamiealquiza/tachymeter v2.0.0+incompatible h1:mGiF1DGo8l6vnGT8FXNNcIXht/YmjzfraiUprXYwJ6g=

--- a/methods.go
+++ b/methods.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/jamiealquiza/bicache/sll"
+	"github.com/jamiealquiza/bicache/v2/sll"
 	"github.com/jamiealquiza/fnv"
 )
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jamiealquiza/bicache"
+	"github.com/jamiealquiza/bicache/v2"
 )
 
 // Benchmarks

--- a/sll/examples/sll-example/main.go
+++ b/sll/examples/sll-example/main.go
@@ -24,7 +24,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jamiealquiza/bicache/sll"
+	"github.com/jamiealquiza/bicache/v2/sll"
 )
 
 func main() {

--- a/sll/sll_test.go
+++ b/sll/sll_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	// "fmt"
 
-	"github.com/jamiealquiza/bicache/sll"
+	"github.com/jamiealquiza/bicache/v2/sll"
 )
 
 func TestHead(t *testing.T) {


### PR DESCRIPTION
This is a sibling PR to #88 -- both address the same issue, just in differing ways.

#86 added a go module file, but because this repo was already on v2+, go modules wants the module to explicitly include the major version in the end of the module, and attempts to set v2.1.0 in go.mod in a consuming repo will result in the following error
```
> go mod tidy
go: errors parsing go.mod:
$repo/go.mod:47:2: require github.com/jamiealquiza/bicache: version "v2.1.0" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```

This PR changes the module and package names to include v2, as documented in the "Major branch" upgrade strategy on the golang module wiki: https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher