### PR TITLE
Create v2 go module

### DIFF
--- a/v2/bicache.go
+++ b/v2/bicache.go
@@ -1,0 +1,565 @@
+// Package bicache implements a two-tier MFU/MRU
+// cache with sharded cache units.
+package bicache
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"log"
+	"math"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jamiealquiza/bicache/v2/sll"
+	"github.com/jamiealquiza/tachymeter"
+)
+
+// Bicache implements a two-tier MFU/MRU
+// cache with sharded cache units.
+type Bicache struct {
+	shards     []*Shard
+	autoEvict  bool
+	ShardCount uint32
+	Size       int
+	paused     uint32
+	done       context.CancelFunc
+}
+
+// Shard implements a cache unit
+// with isolated MFU/MRU caches.
+type Shard struct {
+	sync.RWMutex
+	cacheMap      map[string]*entry
+	mfuCache      *sll.Sll
+	mruCache      *sll.Sll
+	mfuCap        uint
+	mruCap        uint
+	autoEvict     bool
+	ttlCount      uint64
+	ttlMap        map[string]time.Time
+	counters      *counters
+	nearestExpire time.Time
+	noOverflow    bool
+}
+
+// Counters holds Bicache performance
+// data.
+type counters struct {
+	hits      uint64
+	misses    uint64
+	evictions uint64
+	overflows uint64
+}
+
+// Config holds a Bicache configuration.
+// The MFU and MRU cache sizes are set in number
+// of keys. The AutoEvict setting specifies an
+// interval in milliseconds that a background
+// goroutine will handle MRU->MFU promotion
+// and MFU/MRU evictions. Setting this to 0
+// defers the operation until each Set is called
+// on the bicache.
+type Config struct {
+	MFUSize    uint
+	MRUSize    uint
+	AutoEvict  uint
+	EvictLog   bool
+	ShardCount int
+	NoOverflow bool
+}
+
+// Entry is a container type for scored
+// linked list nodes. Entries are referenced
+// in the Bicache cache map and are used to
+// locate which cache a lookup should hit.
+type entry struct {
+	node  *sll.Node
+	state uint8 // 0 = MRU, 1 = MFU
+}
+
+// cacheData is the data container
+// stored in the underlying sll.Node's
+// value.
+type cacheData struct {
+	k string
+	v interface{}
+}
+
+// Stats holds Bicache
+// statistics data.
+type Stats struct {
+	MFUSize    uint   // Number of active MFU keys.
+	MRUSize    uint   // Number of active MRU keys.
+	MFUUsedP   uint   // MFU used in percent.
+	MRUUsedP   uint   // MRU used in percent.
+	MFUMaxSize uint   // Maximum number of MFU keys.
+	MRUMaxSize uint   // Maximum number of MRU keys.
+	Hits       uint64 // Cache hits.
+	Misses     uint64 // Cache misses.
+	Evictions  uint64 // Cache evictions.
+	Overflows  uint64 // Failed sets on full caches.
+}
+
+// New takes a *Config and returns
+// an initialized *Bicache.
+func New(c *Config) (*Bicache, error) {
+	// Check that ShardCount is a power of 2.
+	if (c.ShardCount & (c.ShardCount - 1)) != 0 {
+		return nil, errors.New("Shard count must be a power of 2")
+	}
+
+	if c.MRUSize <= 0 {
+		return nil, errors.New("MRU size must be > 0")
+	}
+
+	// Default to 512 if unset.
+	if c.ShardCount == 0 {
+		c.ShardCount = 512
+	}
+
+	shards := make([]*Shard, c.ShardCount)
+
+	// Get cache sizes for each shard.
+	mfuSize := int(math.Ceil(float64(c.MFUSize) / float64(c.ShardCount)))
+	mruSize := int(math.Ceil(float64(c.MRUSize) / float64(c.ShardCount)))
+
+	// Init shards.
+	for i := 0; i < c.ShardCount; i++ {
+		shards[i] = &Shard{
+			cacheMap:      make(map[string]*entry, mfuSize+mruSize),
+			mfuCache:      sll.New(),
+			mruCache:      sll.New(),
+			mfuCap:        uint(mfuSize),
+			mruCap:        uint(mruSize),
+			ttlMap:        make(map[string]time.Time),
+			counters:      &counters{},
+			nearestExpire: time.Now(),
+			noOverflow:    c.NoOverflow,
+		}
+	}
+
+	ctx, cf := context.WithCancel(context.Background())
+
+	cache := &Bicache{
+		shards:     shards,
+		ShardCount: uint32(c.ShardCount),
+		Size:       (mfuSize + mruSize) * c.ShardCount,
+		done:       cf,
+	}
+
+	// Initialize a background goroutine
+	// for handling promotions and evictions,
+	// if configured.
+	if c.AutoEvict > 0 {
+		cache.autoEvict = true
+		iter := time.Duration(c.AutoEvict)
+		go bgAutoEvict(ctx, cache, iter, c)
+	}
+
+	return cache, nil
+}
+
+// Close stops background tasks and
+// releases any resources. This should be
+// called before removing a reference to
+// a *Bicache if it's desired to be garbage
+// collected cleanly.
+func (b *Bicache) Close() {
+	b.done()
+}
+
+// bgAutoEvict calls evictTTL and promoteEvict for all shards
+// sequentially on the configured iter time interval.
+func bgAutoEvict(ctx context.Context, b *Bicache, iter time.Duration, c *Config) {
+	ttlTachy := tachymeter.New(&tachymeter.Config{Size: c.ShardCount})
+	promoTachy := tachymeter.New(&tachymeter.Config{Size: c.ShardCount})
+	interval := time.NewTicker(time.Millisecond * iter)
+	var evicted int
+	var start time.Time
+
+	defer interval.Stop()
+
+	var ttlStats, promoStats *tachymeter.Metrics
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-interval.C:
+			// Skip this interval if
+			// evictions are paused.
+			if atomic.LoadUint32(&b.paused) == 1 {
+				if c.EvictLog {
+					log.Printf("[Bicache] Evictions Paused")
+				}
+				continue
+			}
+
+			// On the auto eviction interval,
+			// we loop through each shard
+			// and trigger a TTL and promotion/eviction.
+			for _, s := range b.shards {
+				// Run ttl evictions.
+				start = time.Now()
+				evicted = 0
+
+				// At the very first check, nearestExpire
+				// was set to the Bicache initialization time.
+				// This is certain to run at least once.
+				// The first and real nearest expire will be set
+				// in any SetTTL call that's made.
+				if s.nearestExpire.Before(start.Add(iter)) {
+					evicted = s.evictTTL()
+				}
+
+				if c.EvictLog && evicted > 0 {
+					ttlTachy.AddTime(time.Since(start))
+				}
+
+				// Run promotions/overflow evictions.
+				start = time.Now()
+				s.promoteEvict()
+
+				if c.EvictLog {
+					promoTachy.AddTime(time.Since(start))
+				}
+			}
+
+			// Calc eviction/promo stats.
+			ttlStats = ttlTachy.Calc()
+			promoStats = promoTachy.Calc()
+
+			if c.EvictLog {
+				// Log TTL stats if a
+				// TTL eviction was triggered.
+				if ttlStats.Count > 0 {
+					log.Printf("[Bicache EvictTTL] cumulative: %s | min: %s | max: %s\n",
+						ttlStats.Time.Cumulative, ttlStats.Time.Min, ttlStats.Time.Max)
+				}
+
+				// Log PromoteEvict stats.
+				log.Printf("[Bicache PromoteEvict] cumulative: %s | min: %s | max: %s\n",
+					promoStats.Time.Cumulative, promoStats.Time.Min, promoStats.Time.Max)
+			}
+
+			// Reset tachymeter.
+			ttlTachy.Reset()
+			promoTachy.Reset()
+		}
+	}
+}
+
+// Stats returns a *Stats with
+// Bicache statistics data.
+func (b *Bicache) Stats() *Stats {
+	stats := &Stats{}
+	var mfuCap, mruCap float64
+
+	for _, s := range b.shards {
+		s.RLock()
+		stats.MFUSize += s.mfuCache.Len()
+		stats.MRUSize += s.mruCache.Len()
+		s.RUnlock()
+
+		mfuCap += float64(s.mfuCap)
+		mruCap += float64(s.mruCap)
+
+		stats.Hits += atomic.LoadUint64(&s.counters.hits)
+		stats.Misses += atomic.LoadUint64(&s.counters.misses)
+		stats.Evictions += atomic.LoadUint64(&s.counters.evictions)
+		stats.Overflows += atomic.LoadUint64(&s.counters.overflows)
+	}
+
+	stats.MFUMaxSize = uint(mfuCap)
+	stats.MRUMaxSize = uint(mruCap)
+
+	stats.MRUUsedP = uint(float64(stats.MRUSize) / mruCap * 100)
+	// Prevent incorrect stats in MRU-only mode.
+	if mfuCap > 0 {
+		stats.MFUUsedP = uint(float64(stats.MFUSize) / mfuCap * 100)
+	} else {
+		stats.MFUUsedP = 0
+	}
+
+	return stats
+}
+
+// evictTTL evicts expired keys using a mark
+// sweep garbage collection. The number of keys
+// evicted is returned.
+func (s *Shard) evictTTL() int {
+	// Return if we have no TTL'd keys.
+	if atomic.LoadUint64(&s.ttlCount) == 0 {
+		return 0
+	}
+
+	// Tracking marked expirations
+	// in a list.
+	expired := list.New()
+
+	// Set initial nearest expire.
+	nearestExpire := time.Now().Add(time.Second * 2147483647)
+
+	s.RLock()
+
+	now := time.Now()
+	for k, ttl := range s.ttlMap {
+		if now.After(ttl) {
+			// Add to expired.
+			_ = expired.PushBack(k)
+		} else {
+			// If the key isn't expiring, it is
+			// eligible for the nearest expire value.
+			if ttl.Before(nearestExpire) {
+				nearestExpire = ttl
+			}
+		}
+	}
+
+	s.RUnlock()
+
+	// Lock and evict.
+	s.Lock()
+
+	var evicted int
+	for k := expired.Front(); k != nil; k = k.Next() {
+		if n, exists := s.cacheMap[k.Value.(string)]; exists {
+			delete(s.cacheMap, k.Value.(string))
+			delete(s.ttlMap, k.Value.(string))
+			switch n.state {
+			case 0:
+				s.mruCache.Remove(n.node)
+			case 1:
+				s.mfuCache.Remove(n.node)
+			}
+			evicted++
+		}
+	}
+
+	// Update the nearest expire.
+	// If the last TTL'd key was just expired,
+	// this will be left at the initially set value
+	// at the top of evictTTL. This means that the
+	// auto eviction runs will just skip
+	// evictTTL until a SetTTL creates a real
+	// nearest expire timestamp (since it's checking
+	// if the nearest expire happens within the auto
+	// evict interval).
+	s.nearestExpire = nearestExpire
+
+	s.Unlock()
+
+	// Update eviction counters.
+	s.decrementTTLCount(uint64(evicted))
+
+	return evicted
+}
+
+// promoteEvict checks if the MRU exceeds the
+// Config.MRUSize (overflow count) If so, the top <overflow count>
+// MRU scores are checked against the MFU. If any of the top MRU scores
+// are greater than the lowest MFU scores, they are promoted
+// to the MFU (if possible). Any remaining overflow count
+// is evicted from the tail of the MRU.
+func (s *Shard) promoteEvict() {
+	// How far over MRU capacity are we?
+	mruOverflow := int(s.mruCache.Len() - s.mruCap)
+	if mruOverflow <= 0 {
+		return
+	}
+
+	// If MFU cap is 0, shortcut to
+	// LRU-only behavior.
+	if s.mfuCap == 0 {
+		s.Lock()
+		s.evictFromMRUTail(mruOverflow)
+		s.Unlock()
+
+		return
+	}
+
+	// Get the top n MRU elements
+	// where n = MRU capacity overflow.
+	mruToPromoteEvict := s.mruCache.HighScores(mruOverflow)
+
+	// HighScores is expensive.
+	// Get lock immediately after.
+	// May want to sanity check that
+	// keys weren't removed during.
+	s.Lock()
+
+	// Reverse into descending order.
+	sort.Sort(sort.Reverse(mruToPromoteEvict))
+
+	// Check MFU capacity.
+	mfuFree := int(s.mfuCap - s.mfuCache.Len())
+	if mfuFree < 0 {
+		mfuFree = 0
+	}
+
+	var promoted int
+
+	// canPromote is the count of mruOverflow
+	// that can fit into currently unused MFU slots.
+	// This is only likely to be met if this
+	// is a somewhat new cache.
+	var canPromote int
+	if int(mfuFree) >= mruOverflow {
+		canPromote = mruOverflow
+	} else {
+		canPromote = mfuFree
+	}
+
+	// If the MFU is already full,
+	// we can skip the next block.
+	if canPromote == 0 {
+		goto promoteByScore
+	}
+
+	// This is all MRU->MFU promotion
+	// using free slots.
+	if canPromote > 0 {
+		for _, node := range mruToPromoteEvict[:canPromote] {
+			// Don't promote keys with low scores.
+			// We can break since the mruToPromoteEvict
+			// list is in descending order.
+			if node.Score < 2 {
+				break
+			}
+			// Remove from the MRU and
+			// push to the MFU tail.
+			// Update cache state.
+			s.mruCache.Remove(node)
+			s.mfuCache.PushTailNode(node)
+			s.cacheMap[node.Value.(*cacheData).k].state = 1
+
+			promoted++
+		}
+
+		// If we were able to promote
+		// all the overflow, return.
+		if promoted == mruOverflow {
+			s.Unlock()
+			return
+		}
+	}
+
+promoteByScore:
+	s.Unlock()
+	// Get a remainder to either promote by score
+	// to the MFU or ultimately evict from the MRU.
+	mruOverflow -= promoted
+	remainderPosition := promoted
+
+	// Some vars are declared up here
+	// due to the goto jumps.
+
+	// Counter to track
+	// how many from the MRU keys
+	// were promoted by score.
+	var promotedByScore int
+
+	// We're here on two conditions:
+	// 1) The MFU was full. We need to handle all mruToPromoteEvict (canPromote == 0).
+	// 2) We promoted some mruToPromoteEvict and have leftovers (canPromote > 0).
+
+	// Get top MRU scores and bottom MFU scores to compare.
+	bottomMFU := s.mfuCache.LowScores(mruOverflow)
+
+	// If the lowest MFU score is higher than the lowest
+	// score to promote, none of these are eligible.
+	if len(bottomMFU) == 0 || bottomMFU[0].Score >= mruToPromoteEvict[remainderPosition].Score {
+		goto evictFromMRUTail
+	}
+
+	// Otherwise, scan for a replacement.
+	s.Lock()
+scorePromote:
+	for _, mruNode := range mruToPromoteEvict[remainderPosition:] {
+		for i, mfuNode := range bottomMFU {
+			if mruNode.Score > mfuNode.Score {
+				// Push the evicted MFU node to the head
+				// of the MRU and update state.
+				s.mfuCache.Remove(mfuNode)
+				s.mruCache.PushHeadNode(mfuNode)
+				s.cacheMap[mfuNode.Value.(*cacheData).k].state = 0
+
+				// Promote the MRU node to the MFU and
+				// update state.
+				s.mruCache.Remove(mruNode)
+				s.mfuCache.PushTailNode(mruNode)
+				s.cacheMap[mruNode.Value.(*cacheData).k].state = 1
+
+				promotedByScore++
+
+				// Remove the replaced MFU node from the
+				// bottomMFU list so it's not attempted twice.
+				bottomMFU = append(bottomMFU[:i], bottomMFU[i+1:]...)
+				break
+			}
+			if i == len(bottomMFU)-1 {
+				break scorePromote
+			}
+		}
+
+	}
+
+	s.Unlock()
+
+evictFromMRUTail:
+
+	s.Lock()
+
+	// What's the overflow remainder count?
+	toEvict := mruOverflow - promotedByScore
+	// Evict this many from the MRU tail.
+	if toEvict > 0 {
+		s.evictFromMRUTail(toEvict)
+	}
+
+	s.Unlock()
+}
+
+// evictFromMRUTail evicts n keys from the tail
+// of the MRU cache.
+func (s *Shard) evictFromMRUTail(n int) {
+	ttlStart := len(s.ttlMap)
+
+	for i := 0; i < n; i++ {
+		node := s.mruCache.Tail()
+		delete(s.cacheMap, node.Value.(*cacheData).k)
+		delete(s.ttlMap, node.Value.(*cacheData).k)
+		s.mruCache.RemoveTail()
+	}
+
+	// Update the ttlCount.
+	ttlEvicted := ttlStart - len(s.ttlMap)
+	s.decrementTTLCount(uint64(ttlEvicted))
+	// Update eviction count.
+	// Excludes TTL evictions since the
+	// decrementTTLCount handles that for us.
+	atomic.AddUint64(&s.counters.evictions, uint64(n-ttlEvicted))
+}
+
+// decrementTTLCount decrements the Bicache.ttlCount
+// value by n. Even though these operations are atomic,
+// this method should only be called when the shard is locked
+// for other consistency reasons.
+func (s *Shard) decrementTTLCount(n uint64) {
+	// Prevents some obscure
+	// scenario where ttlCount is
+	// already 0 and we rollover to
+	// uint max.
+	if s.ttlCount-n > s.ttlCount {
+		atomic.StoreUint64(&s.ttlCount, 0)
+	} else {
+		atomic.AddUint64(&s.ttlCount, ^uint64(n-1))
+	}
+
+	// Increment the evictions count
+	// by n, regardless.
+	atomic.AddUint64(&s.counters.evictions, n)
+}

--- a/v2/bicache_test.go
+++ b/v2/bicache_test.go
@@ -1,0 +1,224 @@
+package bicache_test
+
+import (
+	"log"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jamiealquiza/bicache/v2"
+)
+
+func TestNew(t *testing.T) {
+	// MFU size, MRU size, shard count, expected bicache size.
+	configExpected := [][4]int{
+		[4]int{0, 1, 512, 512},
+		[4]int{1, 2, 512, 1024},
+		[4]int{256, 1024, 512, 1536},
+		[4]int{10000, 30000, 512, 40448}}
+
+	// Check that the cache sizes are fitted to the
+	// minimum for the number of shards specified.
+	for _, n := range configExpected {
+		c, _ := bicache.New(&bicache.Config{
+			MFUSize:    uint(n[0]),
+			MRUSize:    uint(n[1]),
+			ShardCount: n[2],
+		})
+
+		if c.Size != n[3] {
+			t.Errorf("Expected bicache size %d, got %d", n[3], c.Size)
+		}
+	}
+}
+
+func TestStats(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  3000,
+	})
+
+	stats := c.Stats()
+
+	if stats.MFUSize != 0 {
+		t.Errorf("Expected MFU size 0, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUSize != 0 {
+		t.Errorf("Expected MRU size 0, got %d", stats.MRUSize)
+	}
+
+	if stats.MFUMaxSize != 10 {
+		t.Errorf("Expected MFUMaxSize 10, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUMaxSize != 30 {
+		t.Errorf("Expected MRUMaxSize 30, got %d", stats.MRUSize)
+	}
+
+	if stats.MFUUsedP != 0 {
+		t.Errorf("Expected MFU usedp 0, got %d", stats.MFUUsedP)
+	}
+
+	if stats.MRUUsedP != 0 {
+		t.Errorf("Expected MRU usedp 0, got %d", stats.MRUUsedP)
+	}
+
+	if stats.Hits != 0 {
+		t.Errorf("Expected 0 hits, got %d", stats.Hits)
+	}
+
+	if stats.Misses != 0 {
+		t.Errorf("Expected 0 misses, got %d", stats.Misses)
+	}
+
+	if stats.Evictions != 0 {
+		t.Errorf("Expected 0 evictions, got %d", stats.Evictions)
+	}
+
+	if stats.Overflows != 0 {
+		t.Errorf("Expected 0 overflows, got %d", stats.Overflows)
+	}
+
+	for i := 0; i < 50; i++ {
+		c.Set(strconv.Itoa(i), "value")
+		c.Get(strconv.Itoa(i))
+		c.Get(strconv.Itoa(i))
+	}
+
+	c.Get("nil")
+
+	log.Printf("Sleeping for 4 seconds to allow evictions")
+	time.Sleep(4 * time.Second)
+
+	stats = c.Stats()
+
+	if stats.MFUSize != 10 {
+		t.Errorf("Expected MFU size 10, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUSize != 30 {
+		t.Errorf("Expected MRU size 30, got %d", stats.MRUSize)
+	}
+
+	if stats.MFUMaxSize != 10 {
+		t.Errorf("Expected MFUMaxSize 10, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUMaxSize != 30 {
+		t.Errorf("Expected MRUMaxSize 30, got %d", stats.MRUSize)
+	}
+
+	if stats.MFUUsedP != 100 {
+		t.Errorf("Expected MFU usedp 100, got %d", stats.MFUUsedP)
+	}
+
+	if stats.MRUUsedP != 100 {
+		t.Errorf("Expected MRU usedp 100, got %d", stats.MRUUsedP)
+	}
+
+	if stats.Hits != 100 {
+		t.Errorf("Expected 100 hits, got %d", stats.Hits)
+	}
+
+	if stats.Misses != 1 {
+		t.Errorf("Expected 1 misses, got %d", stats.Misses)
+	}
+
+	if stats.Evictions != 10 {
+		t.Errorf("Expected 10 evictions, got %d", stats.Evictions)
+	}
+
+	if stats.Overflows != 0 {
+		t.Errorf("Expected 0 overflows, got %d", stats.Overflows)
+	}
+}
+
+func TestEvictTtl(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  1000,
+	})
+
+	c.SetTTL("5", "value", 5)
+	c.SetTTL("30", "value", 30)
+
+	if v := c.Get("5"); v != "value" {
+		t.Error("Expected hit")
+	}
+
+	log.Printf("Sleeping for 6 seconds to allow evictions")
+	time.Sleep(6 * time.Second)
+
+	// Check that the value was evicted.
+	if v := c.Get("5"); v != nil {
+		t.Error("Expected miss")
+	}
+
+	stats := c.Stats()
+
+	if stats.MRUSize != 1 || stats.Evictions != 1 {
+		t.Error("Unexpected stats")
+	}
+}
+
+func TestPromoteEvict(t *testing.T) {
+	// Also covers MRU tail eviction.
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  5000,
+	})
+
+	for i := 0; i < 50; i++ {
+		c.Set(strconv.Itoa(i), "value")
+	}
+
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+
+	c.Get("1")
+	c.Get("1")
+	c.Get("1")
+
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+
+	log.Printf("Sleeping for 6 seconds to allow evictions")
+	time.Sleep(6 * time.Second)
+
+	stats := c.Stats()
+
+	if stats.MFUSize != 3 {
+		t.Error("Unexpected MFU count")
+	}
+
+	if stats.MRUSize != 30 {
+		t.Error("Unexpected MRU count")
+	}
+
+	// Check that the expected MRU members exist.
+	for k := 20; k <= 49; k++ {
+		if v := c.Get(strconv.Itoa(k)); v == nil {
+			t.Errorf("Unexpected miss for key %d", k)
+		}
+	}
+
+	// Check that the expected MFU members exist.
+	for _, k := range []int{0, 1, 2} {
+		if v := c.Get(strconv.Itoa(k)); v == nil {
+			t.Errorf("Unexpected miss for key %d", k)
+		}
+	}
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,8 @@
+module github.com/jamiealquiza/bicache/v2
+
+go 1.15
+
+require (
+	github.com/jamiealquiza/fnv v1.0.0
+	github.com/jamiealquiza/tachymeter v2.0.0+incompatible
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,4 @@
+github.com/jamiealquiza/fnv v1.0.0 h1:4NwlkaoZiLhqk008EY5+MTGVPRQZgRG/6B7+jN7ueT8=
+github.com/jamiealquiza/fnv v1.0.0/go.mod h1:iJRnFlvFvZpWKZd+KljYXcyQLasMIKAVuQhx63P4DUk=
+github.com/jamiealquiza/tachymeter v2.0.0+incompatible h1:mGiF1DGo8l6vnGT8FXNNcIXht/YmjzfraiUprXYwJ6g=
+github.com/jamiealquiza/tachymeter v2.0.0+incompatible/go.mod h1:Ayf6zPZKEnLsc3winWEXJRkTBhdHo58HODAu1oFJkYU=

--- a/v2/methods.go
+++ b/v2/methods.go
@@ -1,0 +1,305 @@
+// Package bicache implements a two-tier MFU/MRU
+// cache with sharded cache units.
+package bicache
+
+import (
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/jamiealquiza/bicache/v2/sll"
+	"github.com/jamiealquiza/fnv"
+)
+
+// KeyInfo holds a key name, state (0: MRU, 1: MFU)
+// and cache score.
+type KeyInfo struct {
+	Key   string
+	State uint8
+	Score uint64
+}
+
+// ListResults is a container that holds results from
+// from a List method (as keyInfo), allowing sorting of
+// available key names by score.
+type ListResults []*KeyInfo
+
+// listResults methods to satisfy the sort interface.
+
+func (lr ListResults) Len() int {
+	return len(lr)
+}
+
+func (lr ListResults) Less(i, j int) bool {
+	// Note operator set for desc. order.
+	return lr[i].Score > lr[j].Score
+}
+
+func (lr ListResults) Swap(i, j int) {
+	lr[i], lr[j] = lr[j], lr[i]
+}
+
+// Bicache is storing a [2]interface{}
+// as the underlying sll node's value.
+// Position 0 is the node's key and position
+// 1 is the value. This is done so that
+// the node a node can be looked up in the
+// cache map if the key would otherwise be
+// unknown.
+
+// Set takes a key and value and creates
+// and entry in the MRU cache. If the key
+// already exists, the value is updated.
+func (b *Bicache) Set(k string, v interface{}) bool {
+	s := b.shards[b.getShard(k)]
+
+	s.Lock()
+	// If the entry exists, update. If not,
+	// create at the tail of the MRU cache.
+	if n, exists := s.cacheMap[k]; !exists {
+		// Return false if we're at capacity
+		// and no overflow is set.
+		if s.noOverflow && s.mruCache.Len() >= s.mruCap {
+			s.Unlock()
+			atomic.AddUint64(&s.counters.overflows, 1)
+			return false
+		}
+
+		// Create at the MRU tail.
+		s.cacheMap[k] = &entry{
+			node: s.mruCache.PushHead(&cacheData{k: k, v: v}),
+		}
+	} else {
+		n.node.Value.(*cacheData).v = v
+		if n.state == 0 {
+			s.mruCache.MoveToHead(n.node)
+		}
+	}
+
+	s.Unlock()
+
+	// promoteEvict on write if it's
+	// not being handled automatically.
+	if !b.autoEvict {
+		s.promoteEvict()
+	}
+
+	return true
+}
+
+// SetTTL is the same as set but accepts a
+// parameter t to specify a TTL in seconds.
+func (b *Bicache) SetTTL(k string, v interface{}, t int32) bool {
+	s := b.shards[b.getShard(k)]
+
+	s.Lock()
+
+	// Set TTL expiration
+	expiration := time.Now().Add(time.Second * time.Duration(t))
+	s.ttlMap[k] = expiration
+
+	// Increment TTL counter.
+	atomic.AddUint64(&s.ttlCount, 1)
+
+	// Proceed to normal Set operation.
+	// This logic is duplicated for now
+	// to skip releasing / re-acquiring a mutex.
+
+	// If the entry exists, update. If not,
+	// create at the tail of the MRU cache.
+	if n, exists := s.cacheMap[k]; !exists {
+		// Return false if we're at capacity
+		// and no overflow is set.
+		if s.noOverflow && s.mruCache.Len() >= s.mruCap {
+			s.Unlock()
+			atomic.AddUint64(&s.counters.overflows, 1)
+			return false
+		}
+		// Create at the MRU tail.
+		s.cacheMap[k] = &entry{
+			node: s.mruCache.PushHead(&cacheData{k: k, v: v}),
+		}
+	} else {
+		n.node.Value.(*cacheData).v = v
+		if n.state == 0 {
+			s.mruCache.MoveToHead(n.node)
+		}
+	}
+
+	// Update the nearest expire.
+	if expiration.Before(s.nearestExpire) {
+		s.nearestExpire = expiration
+	}
+
+	s.Unlock()
+
+	// promoteEvict on write if it's
+	// not being handled automatically.
+	if !b.autoEvict {
+		s.promoteEvict()
+	}
+
+	return true
+}
+
+// Get takes a key and returns the value. Every get
+// on a key increases the key score.
+func (b *Bicache) Get(k string) interface{} {
+	s := b.shards[b.getShard(k)]
+
+	s.RLock()
+
+	if n, exists := s.cacheMap[k]; exists {
+		read := n.node.Read()
+
+		s.RUnlock()
+		atomic.AddUint64(&s.counters.hits, 1)
+
+		return read.(*cacheData).v
+	}
+
+	s.RUnlock()
+	atomic.AddUint64(&s.counters.misses, 1)
+
+	return nil
+}
+
+// Del deletes a key.
+func (b *Bicache) Del(k string) {
+	s := b.shards[b.getShard(k)]
+
+	s.Lock()
+
+	if n, exists := s.cacheMap[k]; exists {
+		delete(s.cacheMap, k)
+		delete(s.ttlMap, k)
+		switch n.state {
+		case 0:
+			s.mruCache.Remove(n.node)
+		case 1:
+			s.mfuCache.Remove(n.node)
+		}
+	}
+
+	s.Unlock()
+}
+
+// List returns all key names, states, and scores
+// sorted in descending order by score. Returns n
+// top restults.
+func (b *Bicache) List(n int) ListResults {
+	// Make a ListResults large enough to hold the
+	// number of cache items present in both cache tiers.
+	lr := make(ListResults, 0, b.Size)
+
+	var i int
+	for _, shard := range b.shards {
+		for k, v := range shard.cacheMap {
+			lr = append(lr, &KeyInfo{
+				Key:   k,
+				State: v.state,
+				Score: v.node.Score,
+			})
+			i++
+		}
+	}
+
+	sort.Sort(lr)
+	// return the number
+	// of items requested.
+	if n < len(lr) {
+		return lr[:n]
+	}
+
+	return lr
+}
+
+// FlushMRU flushes all MRU entries.
+func (b *Bicache) FlushMRU() error {
+	// Traverse shards.
+	for _, s := range b.shards {
+		s.Lock()
+
+		// Remove cacheMap entries.
+		for k, v := range s.cacheMap {
+			if v.state == 0 {
+				delete(s.cacheMap, k)
+				delete(s.ttlMap, k)
+			}
+		}
+
+		s.mruCache = sll.New()
+
+		s.Unlock()
+	}
+
+	return nil
+}
+
+// FlushMFU flushes all MFU entries.
+func (b *Bicache) FlushMFU() error {
+	// Traverse shards.
+	for _, s := range b.shards {
+		s.Lock()
+
+		// Remove cacheMap entries.
+		for k, v := range s.cacheMap {
+			if v.state == 1 {
+				delete(s.cacheMap, k)
+				delete(s.ttlMap, k)
+			}
+		}
+
+		s.mfuCache = sll.New()
+
+		s.Unlock()
+	}
+
+	return nil
+}
+
+// FlushAll flushes all cache entries.
+// Flush all is much faster than combining both a
+// FlushMRU and FlushMFU call.
+func (b *Bicache) FlushAll() error {
+	// Traverse and reset shard caches.
+	for _, s := range b.shards {
+		s.Lock()
+
+		// Reset cache and TTL maps and nearest expire.
+		s.cacheMap = make(map[string]*entry, s.mfuCap+s.mruCap)
+		s.ttlMap = make(map[string]time.Time)
+		s.nearestExpire = time.Now().Add(time.Second * 2147483647)
+
+		// Create new caches.
+		s.mfuCache = sll.New()
+		s.mruCache = sll.New()
+
+		s.Unlock()
+	}
+
+	return nil
+}
+
+// Pause suspends normal and TTL evictions.
+// If eviction logging is enabled, bicache
+// will log that evictions are paused
+// at each interval if paused.
+func (b *Bicache) Pause() error {
+	atomic.StoreUint32(&b.paused, 1)
+	return nil
+}
+
+// Resume resumes normal and TTL evictions.
+func (b *Bicache) Resume() error {
+	atomic.StoreUint32(&b.paused, 0)
+	return nil
+}
+
+// getShard returns the shard index
+// using fnv-1 32 bit based hash-routing
+// (we can mask for a modulo since ShardCount
+// must be a power of 2).
+func (b *Bicache) getShard(k string) int {
+	return int(fnv.Hash32(k)) & int(b.ShardCount-1)
+}

--- a/v2/methods_test.go
+++ b/v2/methods_test.go
@@ -1,0 +1,522 @@
+package bicache_test
+
+import (
+	"log"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jamiealquiza/bicache/v2"
+)
+
+// Benchmarks
+
+func BenchmarkGet(b *testing.B) {
+	b.StopTimer()
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10000,
+		MRUSize:    600000,
+		ShardCount: 1024,
+		AutoEvict:  30000,
+	})
+
+	keys := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		k := strconv.Itoa(i)
+		keys[i] = k
+		c.Set(k, "my value")
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.Get(keys[i])
+	}
+}
+
+func BenchmarkSet(b *testing.B) {
+	b.StopTimer()
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10000,
+		MRUSize:    600000,
+		ShardCount: 1024,
+		AutoEvict:  30000,
+	})
+
+	keys := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		k := strconv.Itoa(i)
+		keys[i] = k
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set(keys[i], "my value")
+	}
+}
+
+func BenchmarkSetTTL(b *testing.B) {
+	b.StopTimer()
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10000,
+		MRUSize:    600000,
+		ShardCount: 1024,
+		AutoEvict:  30000,
+	})
+
+	keys := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		k := strconv.Itoa(i)
+		keys[i] = k
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.SetTTL(keys[i], "my value", 3600)
+	}
+}
+
+func BenchmarkDel(b *testing.B) {
+	b.StopTimer()
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10000,
+		MRUSize:    600000,
+		ShardCount: 1024,
+		AutoEvict:  30000,
+	})
+
+	keys := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		k := strconv.Itoa(i)
+		keys[i] = k
+	}
+
+	for i := 0; i < b.N; i++ {
+		c.Set(keys[i], "my value")
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.Del(keys[i])
+	}
+}
+
+func BenchmarkList(b *testing.B) {
+	b.StopTimer()
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10000,
+		MRUSize:    600000,
+		ShardCount: 1024,
+		AutoEvict:  30000,
+	})
+
+	keys := make([]string, b.N/2)
+	for i := 0; i < b.N/2; i++ {
+		k := strconv.Itoa(i)
+		keys[i] = k
+	}
+
+	for i := 0; i < b.N/2; i++ {
+		c.Set(keys[i], "my value")
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.List(b.N / 2)
+	}
+}
+
+// Tests
+
+func TestSetGet(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  10000,
+	})
+
+	ok := c.Set("key", "value")
+	if !ok {
+		t.Error("Set failed")
+	}
+
+	if c.Get("key") != "value" {
+		t.Error("Get failed")
+	}
+
+	// Ensure that updates work.
+	ok = c.Set("key", "value2")
+	if !ok {
+		t.Error("Update failed")
+	}
+
+	if c.Get("key") != "value2" {
+		t.Error("Update failed")
+	}
+}
+
+func TestSetTTL(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  1000,
+	})
+
+	ok := c.SetTTL("key", "value", 3)
+	if !ok {
+		t.Error("Set failed")
+	}
+
+	if c.Get("key") != "value" {
+		t.Error("Get failed")
+	}
+
+	log.Printf("Sleeping for 4 seconds to allow evictions")
+	time.Sleep(4 * time.Second)
+
+	if c.Get("key") != nil {
+		t.Error("Key TTL expiration failed")
+	}
+}
+
+func TestDel(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  10000,
+	})
+
+	c.Set("key", "value")
+	c.Del("key")
+
+	if c.Get("key") != nil {
+		t.Error("Delete failed")
+	}
+
+	stats := c.Stats()
+
+	if stats.MRUSize != 0 {
+		t.Errorf("Expected MRU size 0, got %d", stats.MRUSize)
+	}
+}
+
+func TestList(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 2,
+		AutoEvict:  1000,
+	})
+
+	for i := 0; i < 40; i++ {
+		c.Set(strconv.Itoa(i), "value")
+	}
+
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+
+	c.Get("1")
+	c.Get("1")
+	c.Get("1")
+
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+
+	log.Printf("Sleeping for 2 seconds to allow evictions")
+	time.Sleep(2 * time.Second)
+
+	list := c.List(5)
+
+	if len(list) != 5 {
+		t.Errorf("Exected list output len of 5, got %d", len(list))
+	}
+
+	// Can only reliably expect the MFU nodes
+	// in the list output. Check that the top3
+	// are what's expected.
+	expected := []string{"2", "0", "1"}
+	for i, n := range list[:3] {
+		if n.Key != expected[i] {
+			t.Errorf(`Expected key "%s" at list element %d, got "%s"`,
+				expected[i], i, n.Key)
+		}
+	}
+}
+
+func TestFlushMRU(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 1,
+		AutoEvict:  1000,
+	})
+
+	for i := 0; i < 30; i++ {
+		c.Set(strconv.Itoa(i), "value")
+	}
+
+	// Check before.
+	stats := c.Stats()
+	if stats.MRUSize != 30 {
+		t.Errorf("Expected MFU size of 30, got %d", stats.MFUSize)
+	}
+
+	c.FlushMRU()
+
+	// Check after.
+	stats = c.Stats()
+	if stats.MRUSize != 0 {
+		t.Errorf("Expected MRU size of 0, got %d", stats.MRUSize)
+	}
+}
+
+func TestFlushMFU(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 1,
+		AutoEvict:  1000,
+	})
+
+	for i := 0; i < 40; i++ {
+		c.Set(strconv.Itoa(i), "value")
+	}
+
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+
+	c.Get("1")
+	c.Get("1")
+	c.Get("1")
+
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+
+	log.Printf("Sleeping for 2 seconds to allow promotions")
+	time.Sleep(2 * time.Second)
+
+	// MFU promotion is already tested in bicache_tests.go
+	// TestPromoteEvict. This is somewhat of a dupe, but
+	// ensure that if we're testing for a length of 0
+	// after a flush that it wasn't 0 to begin with.
+
+	// Check before.
+	stats := c.Stats()
+	if stats.MFUSize != 3 {
+		t.Errorf("Expected MFU size of 3, got %d", stats.MFUSize)
+	}
+
+	c.FlushMFU()
+
+	// Check after.
+	stats = c.Stats()
+	if stats.MFUSize != 0 {
+		t.Errorf("Expected MFU size of 0, got %d", stats.MFUSize)
+	}
+}
+
+func TestFlushAll(t *testing.T) {
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 1,
+		AutoEvict:  1000,
+	})
+
+	for i := 0; i < 40; i++ {
+		c.Set(strconv.Itoa(i), "value")
+	}
+
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+	c.Get("0")
+
+	c.Get("1")
+	c.Get("1")
+	c.Get("1")
+
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+	c.Get("2")
+
+	log.Printf("Sleeping for 2 seconds to allow promotions")
+	time.Sleep(2 * time.Second)
+
+	// Check before.
+	stats := c.Stats()
+
+	if stats.MFUSize != 3 {
+		t.Errorf("Expected MFU size of 3, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUSize != 30 {
+		t.Errorf("Expected MFU size of 30, got %d", stats.MFUSize)
+	}
+
+	c.FlushAll()
+
+	// Check after.
+	stats = c.Stats()
+
+	if stats.MFUSize != 0 {
+		t.Errorf("Expected MFU size of 0, got %d", stats.MFUSize)
+	}
+
+	if stats.MRUSize != 0 {
+		t.Errorf("Expected MRU size of 0, got %d", stats.MRUSize)
+	}
+}
+
+func TestIntegrity(t *testing.T) {
+	words := []string{"&c", "'d", "'em", "'ll", "'m", "'mid", "'midst", "'mongst", "'prentice", "'re", "'s", "'sblood", "'sbodikins", "'sdeath", "'sfoot", "'sheart", "'shun", "'slid", "'slife", "'slight", "'snails", "'strewth", "'t", "'til", "'tis", "'twas", "'tween", "'twere", "'twill", "'twixt", "'twould", "'un", "'ve", "1080", "10th", "1st", "2", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "a", "a'", "a's", "a/c", "a1", "aa", "aaa", "aah", "aahed", "aahing", "aahs", "aal", "aalii", "aaliis", "aals", "aam", "aardvark", "aardvarks", "aardwolf", "aardwolves", "aargh", "aaron", "aaronic", "aarrgh", "aarrghh", "aas", "aasvogel", "aasvogels", "ab", "aba", "abac", "abaca", "abacas", "abacate", "abacaxi", "abacay", "abaci", "abacinate", "abacination", "abacisci", "abaciscus", "abacist", "aback", "abacli", "abacot", "abacterial", "abactinal", "abactinally", "abaction", "abactor", "abaculi", "abaculus", "abacus", "abacuses", "abada", "abaddon", "abadejo", "abadengo", "abadia", "abaff", "abaft", "abaisance", "abaised", "abaiser", "abaisse", "abaissed", "abaka", "abakas", "abalation", "abalienate", "abalienated", "abalienating", "abalienation", "abalone", "abalones", "abamp", "abampere", "abamperes", "abamps", "aband", "abandon", "abandonable", "abandoned", "abandonedly", "abandonee", "abandoner", "abandoners", "abandoning", "abandonment", "abandonments", "abandons", "abandum", "abanet", "abanga", "abannition", "abapical", "abaptiston", "abaptistum", "abarthrosis", "abarticular", "abarticulation", "abas", "abase", "abased", "abasedly", "abasedness", "abasement", "abasements", "abaser", "abasers", "abases", "abash", "abashed", "abashedly", "abashedness", "abashes", "abashing", "abashless", "abashlessly", "abashment", "abashments", "abasia", "abasias", "abasic", "abasing", "abasio", "abask", "abassi", "abastard", "abastardize", "abastral", "abatable", "abatage", "abate", "abated", "abatement", "abatements", "abater", "abaters", "abates", "abatic", "abating", "abatis", "abatised", "abatises", "abatjour", "abatjours", "abaton", "abator", "abators", "abattage", "abattis", "abattised", "abattises", "abattoir", "abattoirs", "abattu", "abattue", "abature", "abaue", "abave", "abaxial", "abaxile", "abay", "abayah", "abaze", "abb", "abba", "abbacies", "abbacomes", "abbacy", "abbandono", "abbas", "abbasi", "abbasid", "abbassi", "abbate", "abbatial", "abbatical", "abbatie", "abbaye", "abbe", "abbes", "abbess", "abbesses", "abbest", "abbevillian", "abbey", "abbey's", "abbeys", "abbeystead", "abbeystede", "abboccato", "abbogada", "abbot", "abbot's", "abbotcies", "abbotcy", "abbotnullius", "abbotric", "abbots", "abbotship", "abbotships", "abbott", "abbozzo", "abbr", "abbrev", "abbreviatable", "abbreviate", "abbreviated", "abbreviately", "abbreviates", "abbreviating", "abbreviation", "abbreviations", "abbreviator", "abbreviators", "abbreviatory", "abbreviature", "abbroachment", "abby", "abc", "abcess", "abcissa", "abcoulomb", "abd", "abdal", "abdali", "abdaria", "abdat", "abdest", "abdicable", "abdicant", "abdicate", "abdicated", "abdicates", "abdicating", "abdication", "abdications", "abdicative", "abdicator", "abditive", "abditory", "abdom", "abdomen", "abdomen's", "abdomens", "abdomina", "abdominal", "abdominales", "abdominalia", "abdominalian", "abdominally", "abdominals", "abdominoanterior", "abdominocardiac", "abdominocentesis", "abdominocystic", "abdominogenital", "abdominohysterectomy", "abdominohysterotomy", "abdominoposterior", "abdominoscope", "abdominoscopy", "abdominothoracic", "abdominous", "abdominovaginal", "abdominovesical", "abduce", "abduced", "abducens", "abducent", "abducentes", "abduces", "abducing", "abduct", "abducted", "abducting", "abduction", "abduction's", "abductions", "abductor", "abductor's", "abductores", "abductors", "abducts", "abeam", "abear", "abearance", "abecedaire", "abecedaria", "abecedarian", "abecedarians", "abecedaries", "abecedarium", "abecedarius", "abecedary", "abed", "abede", "abedge", "abegge", "abeigh", "abel", "abele", "abeles", "abelian", "abelite", "abelmosk", "abelmosks", "abelmusk", "abeltree", "abend", "abends", "abenteric", "abepithymia", "aberdavine", "aberdeen", "aberdevine", "aberduvine", "abernethy", "aberr", "aberrance", "aberrancies", "aberrancy", "aberrant", "aberrantly", "aberrants", "aberrate", "aberrated", "aberrating", "aberration", "aberrational", "aberrations", "aberrative", "aberrator", "aberrometer", "aberroscope", "aberuncate", "aberuncator", "abesse", "abessive", "abet", "abetment", "abetments", "abets", "abettal", "abettals", "abetted", "abetter", "abetters", "abetting", "abettor", "abettors", "abevacuation", "abey", "abeyance", "abeyances", "abeyancies", "abeyancy", "abeyant", "abfarad", "abfarads", "abhenries", "abhenry", "abhenrys", "abhinaya", "abhiseka", "abhominable", "abhor", "abhorred", "abhorrence", "abhorrences", "abhorrency", "abhorrent", "abhorrently", "abhorrer", "abhorrers", "abhorrible", "abhorring", "abhors", "abib", "abichite", "abidal", "abidance", "abidances", "abidden", "abide", "abided", "abider", "abiders", "abides", "abidi", "abiding", "abidingly", "abidingness", "abiegh", "abience", "abient", "abietate", "abietene", "abietic", "abietin", "abietineous", "abietinic", "abietite", "abigail", "abigails", "abigailship", "abigeat", "abigei", "abigeus", "abilao", "abilene", "abiliment", "abilitable", "abilities", "ability", "ability's", "abilla", "abilo", "abime", "abintestate", "abiogeneses", "abiogenesis", "abiogenesist", "abiogenetic", "abiogenetical", "abiogenetically", "abiogenist", "abiogenous", "abiogeny", "abiological", "abiologically", "abiology", "abioses", "abiosis", "abiotic", "abiotical", "abiotically", "abiotrophic", "abiotrophy", "abir", "abirritant", "abirritate", "abirritated", "abirritating", "abirritation", "abirritative", "abiston", "abit", "abiuret", "abject", "abjectedness", "abjection", "abjections"}
+
+	c, _ := bicache.New(&bicache.Config{
+		MFUSize:    10,
+		MRUSize:    30,
+		ShardCount: 8,
+		AutoEvict:  2000,
+	})
+
+	for _, w := range words {
+		c.Set(w, w)
+	}
+
+	// Test pre-eviction integrity.
+	for _, w := range words {
+		if v := c.Get(w); v != nil && v != w {
+			t.Errorf("Expected value %s, got %s", v, w)
+		}
+	}
+
+	time.Sleep(3 * time.Second)
+
+	// Test post-eviction integrity.
+	for _, w := range words {
+		if v := c.Get(w); v != nil && v != w {
+			t.Errorf("Expected value %s, got %s", v, w)
+		}
+	}
+
+	c.FlushAll()
+
+	// Test integrity for keys that
+	// traverse MFU/MRU.
+
+	// Add item targeted for MFU.
+	c.Set("promoted", "promoted")
+	for i := 0; i < 20; i++ {
+		c.Get("promoted")
+	}
+
+	// Seq scan to exhaust MRU.
+	for _, w := range words {
+		c.Set(w, w)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	// Check that target item
+	// was promoted.
+
+	if c.Get("promoted") != "promoted" {
+		t.Errorf(`Expected MFU item value "promoted", got "%s"`, c.Get("promoted"))
+	}
+
+	// Check MFU key state.
+	keys := c.List(len(words))
+	for _, k := range keys {
+		if k.Key == "promoted" && k.State != 1 {
+			t.Errorf("Expected key state 1, got %d", k.State)
+		}
+	}
+
+	c, _ = bicache.New(&bicache.Config{
+		MFUSize:    1,
+		MRUSize:    30,
+		ShardCount: 1,
+		AutoEvict:  2000,
+	})
+
+	// Add item targeted for MFU
+	// promotion then demotion.
+	c.Set("promoted", "promoted")
+	for i := 0; i < 5; i++ {
+		c.Get("promoted")
+	}
+
+	// Seq scan to exhaust MRU.
+	for _, w := range words {
+		c.Set(w, w)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	// Check that the promoted key
+	// has the proper key state.
+	keys = c.List(len(words))
+	for _, k := range keys {
+		if k.State == 1 && k.Key != "promoted" {
+			t.Errorf(`Expected key name "promoted", got "%s"`, k.Key)
+		}
+	}
+
+	// Set MFU replacement target.
+	c.Set("replacement", "replacement")
+	for i := 0; i < 10; i++ {
+		c.Get("replacement")
+	}
+
+	// Seq scan to exhaust MRU.
+	for _, w := range words {
+		c.Set(w, w)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	// Check that the promoted key
+	// has the proper key state.
+	keys = c.List(len(words))
+	for _, k := range keys {
+		if k.State == 1 && k.Key != "replacement" {
+			t.Errorf(`Expected key name "replacement", got "%s"`, k.Key)
+		}
+	}
+
+	// Check that the demoted key
+	// has the proper key state.
+	keys = c.List(len(words))
+	for _, k := range keys {
+		if k.Key == "promoted" && k.State != 0 {
+			t.Errorf(`Expected key "promoted" to be in state 0, got "%d"`, k.State)
+		}
+	}
+
+	// Previous and new MFU keys
+	// should still be present.
+	if c.Get("replacement") != "replacement" || c.Get("promoted") != "promoted" {
+		t.Errorf("Unexpected cache miss")
+	}
+}

--- a/v2/sll/README.md
+++ b/v2/sll/README.md
@@ -1,0 +1,8 @@
+[![GoDoc](https://godoc.org/github.com/jamiealquiza/bicache/v2/sll?status.svg)](https://godoc.org/github.com/jamiealquiza/bicache/v2/sll)
+
+
+# Sll
+A scored linked list. Sll implements a pointer-based doubly linked list with the addition of methods to fetch nodes by score (high or low) and arbitrarily move nodes between lists. A node score is incremented with each `Read()` method called while retrieving the node's value.
+
+- See [GoDoc](https://godoc.org/github.com/jamiealquiza/bicache/v2/sll) for reference.
+- See [`sll-example`](./sll-example) for example usage.

--- a/v2/sll/examples/sll-example/README.md
+++ b/v2/sll/examples/sll-example/README.md
@@ -1,0 +1,44 @@
+```
+% sll-example 
+[ PushTail objects ]
+one
+two
+three
+four
+five
+six
+seven
+eight
+nine
+ten
+
+[ traverse from tail ]
+ten -> nine -> eight -> seven -> six -> five -> four -> three -> two -> one ->
+
+[ traverse from head ]
+one -> two -> three -> four -> five -> six -> seven -> eight -> nine -> ten ->
+
+[ read tail 3x ]
+ten
+ten
+ten
+
+[ read top 2 scores ]
+Value:nine Score:2
+Value:ten Score:5
+
+[ move tail to head ]
+Current: ten -> nine -> eight -> seven -> six -> five -> four -> three -> two -> one ->
+New: nine -> eight -> seven -> six -> five -> four -> three -> two -> one -> ten ->
+
+[ remove head, tail ]
+Current: nine -> eight -> seven -> six -> five -> four -> three -> two -> one -> ten ->
+New: eight -> seven -> six -> five -> four -> three -> two -> one ->
+
+[ remove second from last node ]
+eight -> six -> five -> four -> three -> two -> one ->
+
+[ read score list ]
+one two three four five six eight
+
+```

--- a/v2/sll/examples/sll-example/main.go
+++ b/v2/sll/examples/sll-example/main.go
@@ -1,0 +1,157 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Jamie Alquiza
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package main
+
+import (
+	"fmt"
+
+	"github.com/jamiealquiza/bicache/v2/sll"
+)
+
+func main() {
+	s := sll.New()
+
+	objects := []string{
+		"one",
+		"two",
+		"three",
+		"four",
+		"five",
+		"six",
+		"seven",
+		"eight",
+		"nine",
+		"ten",
+	}
+
+	fmt.Println("[ PushTail objects ]")
+	for _, o := range objects {
+		fmt.Println(o)
+		_ = s.PushTail(o)
+	}
+
+	fmt.Printf("\n[ traverse from tail ]\n")
+	node := s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	fmt.Printf("\n\n[ traverse from head ]\n")
+	node = s.Head()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Prev() != nil {
+			node = node.Prev()
+		} else {
+			break
+		}
+	}
+
+	fmt.Printf("\n\n[ read tail 3x ]\n")
+	tail := s.Tail()
+	fmt.Println(tail.Read())
+	fmt.Println(tail.Read())
+	fmt.Println(tail.Read())
+
+	fmt.Printf("\n[ read top 2 scores ]\n")
+	top2 := s.HighScores(2)
+	for _, o := range top2 {
+		fmt.Printf("Value:%s Score:%d\n",
+			o.Value, o.Score)
+	}
+
+	fmt.Printf("\n[ move tail to head ]\n")
+	fmt.Printf("Current: ")
+	node = s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	s.MoveToHead(s.Tail())
+
+	fmt.Printf("\nNew: ")
+	node = s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	fmt.Printf("\n\n[ remove head, tail ]\n")
+	fmt.Printf("Current: ")
+	node = s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	s.RemoveHead()
+	s.RemoveTail()
+
+	fmt.Printf("\nNew: ")
+	node = s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	fmt.Printf("\n\n[ remove second from last node ]\n")
+	node = s.Tail().Next()
+	s.Remove(node)
+
+	node = s.Tail()
+	for {
+		fmt.Printf("%s -> ", node.Read())
+		if node.Next() != nil {
+			node = node.Next()
+		} else {
+			break
+		}
+	}
+
+	fmt.Printf("\n\n[ read score list ]\n")
+	for _, n := range s.HighScores(int(s.Len())) {
+		fmt.Printf("%s:%d ", n.Read(), n.Score)
+	}
+	fmt.Println()
+}

--- a/v2/sll/heap.go
+++ b/v2/sll/heap.go
@@ -1,0 +1,69 @@
+package sll
+
+// MinHeap implements a min-heap heap.Interface.
+type MinHeap []*Node
+
+func (mh MinHeap) Len() int { return len(mh) }
+
+func (mh MinHeap) Less(i, j int) bool {
+	return mh[i].Score < mh[j].Score
+}
+
+func (mh MinHeap) Swap(i, j int) {
+	mh[i], mh[j] = mh[j], mh[i]
+}
+
+// Push adds an item to the heap.
+func (mh *MinHeap) Push(x interface{}) {
+	item := x.(*Node)
+	*mh = append(*mh, item)
+}
+
+// Pop removes and returns the root node from the heap.
+func (mh *MinHeap) Pop() interface{} {
+	old := *mh
+	n := len(old)
+	item := old[n-1]
+	*mh = old[0 : n-1]
+	return item
+}
+
+// Peek returns the root node from the heap.
+func (mh *MinHeap) Peek() interface{} {
+	s := *mh
+	return s[0]
+}
+
+// MaxHeap implements a max-heap heap.Interface.
+type MaxHeap []*Node
+
+func (mh MaxHeap) Len() int { return len(mh) }
+
+func (mh MaxHeap) Less(i, j int) bool {
+	return mh[i].Score > mh[j].Score
+}
+
+func (mh MaxHeap) Swap(i, j int) {
+	mh[i], mh[j] = mh[j], mh[i]
+}
+
+// Push adds an item to the heap.
+func (mh *MaxHeap) Push(x interface{}) {
+	item := x.(*Node)
+	*mh = append(*mh, item)
+}
+
+// Pop removes and returns the root node from the heap.
+func (mh *MaxHeap) Pop() interface{} {
+	old := *mh
+	n := len(old)
+	item := old[n-1]
+	*mh = old[0 : n-1]
+	return item
+}
+
+// Peek returns the root node from the heap.
+func (mh *MaxHeap) Peek() interface{} {
+	s := *mh
+	return s[0]
+}

--- a/v2/sll/sll.go
+++ b/v2/sll/sll.go
@@ -1,0 +1,313 @@
+package sll
+
+import (
+	"container/heap"
+	"sort"
+	"sync/atomic"
+)
+
+// Sll is a scored linked list.
+type Sll struct {
+	root *Node
+	len  uint64
+}
+
+// Node is a scored linked list node.
+type Node struct {
+	next  *Node
+	prev  *Node
+	list  *Sll
+	Score uint64
+	Value interface{}
+}
+
+// Next returns the next node in the *Sll.
+func (n *Node) Next() *Node {
+	if n.next != n.list.root {
+		return n.next
+	}
+
+	return nil
+}
+
+// Prev returns the previous node in the *Sll.
+func (n *Node) Prev() *Node {
+	if n.prev != n.list.root {
+		return n.prev
+	}
+
+	return nil
+}
+
+// Copy returns a copy of a *Node.
+func (n *Node) Copy() *Node {
+	return &Node{
+		Score: n.Score,
+		Value: n.Value,
+	}
+}
+
+// New creates a new *Sll.
+func New() *Sll {
+	ll := &Sll{
+		root: &Node{},
+	}
+
+	ll.root.next, ll.root.prev = ll.root, ll.root
+
+	return ll
+}
+
+// NodeScoreList is a slice of *Node
+// sorted by ascending scores.
+type NodeScoreList []*Node
+
+// Read returns a *Node Value and increments the score.
+func (n *Node) Read() interface{} {
+	atomic.AddUint64(&n.Score, 1)
+	return n.Value
+}
+
+// NodeScoreList methods to satisfy the sort interface.
+
+func (nsl NodeScoreList) Len() int {
+	return len(nsl)
+}
+
+func (nsl NodeScoreList) Less(i, j int) bool {
+	return atomic.LoadUint64(&nsl[i].Score) < atomic.LoadUint64(&nsl[j].Score)
+}
+
+func (nsl NodeScoreList) Swap(i, j int) {
+	nsl[i], nsl[j] = nsl[j], nsl[i]
+}
+
+// Len returns the count of nodes in the *Sll.
+func (ll *Sll) Len() uint {
+	return uint(ll.len)
+}
+
+// Head returns the head *Node.
+func (ll *Sll) Head() *Node {
+	return ll.root.prev
+}
+
+// Tail returns the head *Node.
+func (ll *Sll) Tail() *Node {
+	return ll.root.next
+}
+
+// Copy returns a copy of a *Sll.
+func (ll *Sll) Copy() *Sll {
+	newll := New()
+
+	for node := ll.Head(); node != nil; node = node.Prev() {
+		c := node.Copy()
+		newll.PushTailNode(c)
+	}
+
+	return newll
+}
+
+// HighScores takes an integer and returns the
+// respective number of *Nodes with the higest scores
+// sorted in ascending order.
+func (ll *Sll) HighScores(k int) NodeScoreList {
+	h := &MinHeap{}
+
+	if ll.Len() == 0 {
+		return NodeScoreList(*h)
+	}
+
+	heap.Init(h)
+
+	// Add the first k nodes
+	// to the heap. In a high scores selection,
+	// we traverse from the head toward the
+	// tail with the assumption that head nodes
+	// are more probable to have higher
+	// scores than tail nodes.
+	node := ll.Head()
+	for i := 0; i < k && node != nil; i++ {
+		heap.Push(h, node)
+		node = node.Prev()
+	}
+
+	var min = h.Peek().(*Node).Score
+
+	// Iterate the rest of the list
+	// while maintaining the current
+	// heap len.
+	for ; node != nil; node = node.Prev() {
+		if node.Score > min {
+			heap.Push(h, node)
+			heap.Pop(h)
+			min = h.Peek().(*Node).Score
+		}
+	}
+
+	scores := NodeScoreList(*h)
+	sort.Sort(scores)
+
+	return scores
+}
+
+// LowScores takes an integer and returns the
+// respective number of *Nodes with the lowest scores
+// sorted in ascending order.
+func (ll *Sll) LowScores(k int) NodeScoreList {
+	h := &MaxHeap{}
+
+	if ll.Len() == 0 {
+		return NodeScoreList(*h)
+	}
+
+	// In a low scores selection,
+	// we traverse from the tail toward the
+	// head with the assumption that tail nodes
+	// are more probable to have lower
+	// scores than head nodes.
+	node := ll.Tail()
+	for i := 0; i < k && node != nil; i++ {
+		heap.Push(h, node)
+		node = node.Next()
+	}
+
+	var max = h.Peek().(*Node).Score
+
+	// Iterate the rest of the list
+	// while maintaining the current
+	// heap len.
+	for ; node != nil; node = node.Next() {
+		if node.Score < max {
+			heap.Push(h, node)
+			heap.Pop(h)
+			max = h.Peek().(*Node).Score
+		}
+	}
+
+	scores := NodeScoreList(*h)
+	sort.Sort(scores)
+
+	return scores
+}
+
+// insertAt inserts node n
+// at position at in the *Sll.
+func insertAt(n, at *Node) {
+	n.next = at.next
+	at.next = n
+	n.prev = at
+	n.next.prev = n
+}
+
+// pull removes a *Node from
+// its position in the *Sll, but
+// doesn't remove the node from
+// the NodeScoreList. This is used for
+// repositioning nodes.
+func pull(n *Node) {
+	// Link next/prev nodes.
+	n.next.prev, n.prev.next = n.prev, n.next
+	// Remove references.
+	n.next, n.prev = nil, nil
+}
+
+// MoveToHead takes a *Node and moves it
+// to the front of the *Sll.
+func (ll *Sll) MoveToHead(n *Node) {
+	// Short-circuit if this
+	// is already the head.
+	if ll.root.prev == n {
+		return
+	}
+
+	// Pull and move node.
+	pull(n)
+	insertAt(n, ll.root.prev)
+}
+
+// MoveToTail takes a *Node and moves it
+// to the back of the *Sll.
+func (ll *Sll) MoveToTail(n *Node) {
+	// Short-circuit if this
+	// is already the tail.
+	if ll.root.next == n {
+		return
+	}
+
+	// Pull and move node.
+	pull(n)
+	insertAt(n, ll.root)
+}
+
+// PushHead creates a *Node with value v
+// at the head of the *Sll and returns a *Node.
+func (ll *Sll) PushHead(v interface{}) *Node {
+	n := &Node{
+		Value: v,
+		Score: 0,
+		list:  ll,
+	}
+
+	atomic.AddUint64(&ll.len, 1)
+	insertAt(n, ll.root.prev)
+
+	return n
+}
+
+// PushTail creates a *Node with value v
+// at the tail of the *Sll and returns a *Node.
+func (ll *Sll) PushTail(v interface{}) *Node {
+	n := &Node{
+		Value: v,
+		Score: 0,
+		list:  ll,
+	}
+
+	atomic.AddUint64(&ll.len, 1)
+	insertAt(n, ll.root)
+
+	return n
+}
+
+// PushHeadNode pushes an existing node
+// to the head of the *Sll.
+func (ll *Sll) PushHeadNode(n *Node) {
+	n.list = ll
+
+	atomic.AddUint64(&ll.len, 1)
+	insertAt(n, ll.root.prev)
+}
+
+// PushTailNode pushes an existing node
+// to the tail of the *Sll.
+func (ll *Sll) PushTailNode(n *Node) {
+	n.list = ll
+
+	// Increment len.
+	atomic.AddUint64(&ll.len, 1)
+	insertAt(n, ll.root)
+}
+
+// Remove removes a *Node from the *Sll.
+func (ll *Sll) Remove(n *Node) {
+	// Link next/prev nodes.
+	n.next.prev, n.prev.next = n.prev, n.next
+
+	// Remove references.
+	n.next, n.prev = nil, nil
+
+	// Decrement len.
+	atomic.AddUint64(&ll.len, ^uint64(0))
+}
+
+// RemoveHead removes the current *Sll.head.
+func (ll *Sll) RemoveHead() {
+	ll.Remove(ll.root.prev)
+}
+
+// RemoveTail removes the current *Sll.tail.s
+func (ll *Sll) RemoveTail() {
+	ll.Remove(ll.root.next)
+}

--- a/v2/sll/sll_test.go
+++ b/v2/sll/sll_test.go
@@ -1,0 +1,400 @@
+package sll_test
+
+import (
+	"math/rand"
+	"testing"
+	// "fmt"
+
+	"github.com/jamiealquiza/bicache/v2/sll"
+)
+
+func TestHead(t *testing.T) {
+	s := sll.New()
+
+	node := s.PushHead("value")
+	if s.Head() != node {
+		t.Error("Unexpected head node")
+	}
+}
+
+func TestTail(t *testing.T) {
+	s := sll.New()
+
+	node := s.PushTail("value")
+	if s.Tail() != node {
+		t.Error("Unexpected tail node")
+	}
+}
+
+func TestRead(t *testing.T) {
+	s := sll.New()
+
+	s.PushHead("value")
+	if s.Head().Read() != "value" {
+		t.Error("Read method failed")
+	}
+}
+
+func TestPushHead(t *testing.T) {
+	s := sll.New()
+
+	s.PushHead("value")
+	if s.Head().Read() != "value" {
+		t.Errorf(`Expected value "value", got "%s"`, s.Head().Read())
+	}
+}
+
+func TestPushTail(t *testing.T) {
+	s := sll.New()
+
+	s.PushTail("value")
+	if s.Tail().Read() != "value" {
+		t.Errorf(`Expected value "value", got "%s"`, s.Tail().Read())
+	}
+}
+
+func TestNext(t *testing.T) {
+	s := sll.New()
+
+	firstVal := "first"
+	secondVal := "second"
+
+	first := s.PushTail(firstVal)
+	second := s.PushTail(secondVal)
+
+	if second.Next() != first {
+		t.Errorf("Expected node with value %s next, got %s", firstVal, second.Next().Read())
+	}
+}
+
+func TestPrev(t *testing.T) {
+	s := sll.New()
+
+	firstVal := "first"
+	secondVal := "second"
+
+	first := s.PushTail(firstVal)
+	second := s.PushTail(secondVal)
+
+	if first.Prev() != second {
+		t.Errorf("Expected node with value %s next, got %s", firstVal, second.Next().Read())
+	}
+}
+
+func TestLen(t *testing.T) {
+	s := sll.New()
+
+	for i := 0; i < 5; i++ {
+		s.PushTail(i)
+	}
+
+	if s.Len() != 5 {
+		t.Errorf("Expected len 5, got %d", s.Len())
+	}
+}
+
+func TestHighScores(t *testing.T) {
+	s := sll.New()
+
+	nodes := map[int]*sll.Node{}
+
+	for i := 0; i < 5; i++ {
+		nodes[i] = s.PushTail(i)
+	}
+
+	nodes[3].Read()
+	nodes[3].Read()
+	nodes[3].Read()
+
+	nodes[4].Read()
+	nodes[4].Read()
+
+	// Should result in [0,4,3] with read scores
+	// 0,2,3 respectively.
+
+	scores := s.HighScores(3)
+
+	// for node := range nodes {
+	// 	fmt.Printf("node %d: %d\n", node, nodes[node].Score)
+	// }
+	//
+	// fmt.Println("-")
+	//
+	// for _, node := range scores {
+	// 	fmt.Printf("node %d: %d\n", node.Value, node.Score)
+	// }
+
+	if scores[0] != nodes[2] {
+		t.Errorf("Expected scores position 0 node with value 2, got %d", scores[0].Read())
+	}
+
+	if scores[1] != nodes[4] {
+		t.Errorf("Expected scores position 1 node with value 4, got %d", scores[1].Read())
+	}
+
+	if scores[2] != nodes[3] {
+		t.Errorf("Expected scores position 2 node with value 3, got %d", scores[2].Read())
+	}
+}
+
+func TestLowScores(t *testing.T) {
+	s := sll.New()
+
+	nodes := map[int]*sll.Node{}
+
+	for i := 0; i < 3; i++ {
+		nodes[i] = s.PushTail(i)
+	}
+
+	nodes[1].Read()
+	nodes[1].Read()
+	nodes[1].Read()
+
+	nodes[0].Read()
+	nodes[0].Read()
+
+	// Should result in [2, 0, 1]
+	// with read scores of 0, 2, 3 respectively.
+	scores := s.LowScores(3)
+
+	/*
+		for node := range nodes {
+			fmt.Printf("node %d: %d\n", node, nodes[node].Score)
+		}
+
+		fmt.Println("-")
+
+		for _, node := range scores {
+			fmt.Printf("node %d: %d\n", node.Value, node.Score)
+		}
+	*/
+
+	if scores[0] != nodes[2] {
+		t.Errorf("Expected scores position 0 node with value 2, got %d", scores[2].Read())
+	}
+
+	if scores[1] != nodes[0] {
+		t.Errorf("Expected scores position 1 node with value 4, got %d", scores[0].Read())
+	}
+
+	if scores[2] != nodes[1] {
+		t.Errorf("Expected scores position 2 node with value 3, got %d", scores[1].Read())
+	}
+}
+
+func benchmarkHeapScores(b *testing.B, l int) {
+	b.N = 1
+	b.StopTimer()
+
+	// Create/populate an sll.
+	s := sll.New()
+	for i := 0; i < l; i++ {
+		s.PushTail(i)
+	}
+
+	// Perform 3*sll.Len() reads
+	// on random nodes to produce
+	// random node score counts.
+	node := s.Tail()
+	for i := 0; i < 3*l; i++ {
+		node.Read()
+		for j := 0; j < rand.Intn(10); j++ {
+			node = node.Next()
+			if node == nil {
+				node = s.Tail()
+			}
+		}
+	}
+
+	b.ResetTimer()
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		// Call HighScores for
+		// 1/20th the sll len.
+		s.HighScores(l / 20)
+	}
+}
+
+func BenchmarkHeapScores200K(b *testing.B) { benchmarkHeapScores(b, 200000) }
+func BenchmarkHeapScores2M(b *testing.B)   { benchmarkHeapScores(b, 2000000) }
+
+func TestScoresEmpty(t *testing.T) {
+	s := sll.New()
+
+	hScores := s.HighScores(5)
+	lScores := s.LowScores(5)
+
+	// We don't really care about the
+	// len; if it's really broken,
+	// we'd probably have crashed
+	// by now.
+
+	if len(hScores) != 0 {
+		t.Errorf("Expected scores len of 0, got %d", len(hScores))
+	}
+
+	if len(lScores) != 0 {
+		t.Errorf("Expected scores len of 0, got %d", len(lScores))
+	}
+}
+
+func TestMoveToHead(t *testing.T) {
+	s := sll.New()
+
+	for i := 0; i < 10; i++ {
+		s.PushTail(i)
+	}
+
+	node := s.Tail().Next().Next()
+	s.MoveToHead(node)
+
+	// Check head method.
+	if s.Head() != node {
+		t.Errorf(`Expected node with value "%d" at head, got "%d"`,
+			node.Read(), s.Head().Read())
+	}
+
+	// Check total order.
+	expected := []int{9, 8, 6, 5, 4, 3, 2, 1, 0, 7}
+	var i int
+	for n := s.Tail(); n != nil; n = n.Next() {
+		if n.Read() != expected[i] {
+			t.Errorf(`Expected node with vallue "%d", got "%d"`, expected[i], n.Read())
+		}
+		i++
+	}
+}
+
+func TestMoveToTail(t *testing.T) {
+	s := sll.New()
+
+	for i := 0; i < 10; i++ {
+		s.PushTail(i)
+	}
+
+	node := s.Tail().Next().Next()
+	s.MoveToTail(node)
+
+	// Check tail method.
+	if s.Tail() != node {
+		t.Errorf(`Expected node with value "%d" at tail, got "%d"`,
+			node.Read(), s.Tail().Read())
+	}
+
+	// Check total order.
+	expected := []int{7, 9, 8, 6, 5, 4, 3, 2, 1, 0}
+	var i int
+	for n := s.Tail(); n != nil; n = n.Next() {
+		if n.Read() != expected[i] {
+			t.Errorf(`Expected node with value "%d", got "%d"`, expected[i], n.Read())
+		}
+		i++
+	}
+}
+
+func TestPushHeadNode(t *testing.T) {
+	s1 := sll.New()
+	s2 := sll.New()
+
+	s1.PushTail("target")
+	node := s1.Tail()
+	s1.Remove(node)
+
+	s2.PushHead("value")
+	s2.PushHead("value")
+	s2.PushHeadNode(node)
+
+	// Check from the head.
+	if s2.Head() != node {
+		t.Errorf(`Expected node with value "target", got "%s"`, s2.Head().Read())
+	}
+
+	// Ensure the links are correct.
+	if s2.Tail().Next().Next() != node {
+		t.Errorf(`Expected node with value "target", got "%s"`, s2.Tail().Next().Next().Read())
+	}
+}
+
+func TestPushTailNode(t *testing.T) {
+	s1 := sll.New()
+	s2 := sll.New()
+
+	s1.PushTail("target")
+	node := s1.Tail()
+	s1.Remove(node)
+
+	s2.PushHead("value")
+	s2.PushHead("value")
+	s2.PushTailNode(node)
+
+	// Check from the head.
+	if s2.Tail() != node {
+		t.Errorf(`Expected node with value "target", got "%s"`, s2.Tail().Read())
+	}
+
+	// Ensure the links are correct.
+	if s2.Head().Prev().Prev() != node {
+		t.Errorf(`Expected node with value "target", got "%s"`, s2.Head().Prev().Prev().Read())
+	}
+}
+
+func TestRemove(t *testing.T) {
+	s := sll.New()
+
+	nodes := map[int]*sll.Node{}
+
+	for i := 0; i < 3; i++ {
+		nodes[i] = s.PushTail(i)
+	}
+
+	s.Remove(nodes[1])
+
+	if s.Tail().Next().Read() != 0 {
+		t.Errorf(`Expected node with value "0", got "%d"`, s.Tail().Next().Read())
+	}
+
+	scores := s.HighScores(3)
+
+	if len(scores) != 2 {
+		t.Errorf("Expected scores len 2, got %d", len(scores))
+	}
+
+	// This effectively tests the unexported
+	// removeFromScores method.
+	if scores[0] != s.Tail() {
+		t.Error("Unexpected node in scores position 0")
+	}
+
+	if scores[1] != s.Tail().Next() {
+		t.Error("Unexpected node in scores position 1")
+	}
+}
+
+func TestRemoveHead(t *testing.T) {
+	s := sll.New()
+
+	s.PushTail("value")
+	target := s.PushTail("value")
+	s.PushTail("value")
+
+	s.RemoveHead()
+
+	if s.Head() != target {
+		t.Error("Unexpected head node")
+	}
+}
+
+func TestRemoveTail(t *testing.T) {
+	s := sll.New()
+
+	s.PushTail("value")
+	target := s.PushTail("value")
+	s.PushTail("value")
+
+	s.RemoveTail()
+
+	if s.Tail() != target {
+		t.Error("Unexpected tail node")
+	}
+}


### PR DESCRIPTION
This is a sibling of #87 -- either one should address the issue.

#86 added a go module file, but because this repo was already on v2+, go modules wants the module to explicitly include the major version in the end of the module, and attempts to set v2.1.0 in go.mod in a consuming repo will result in the following error
```
> go mod tidy
go: errors parsing go.mod:
$repo/go.mod:47:2: require github.com/jamiealquiza/bicache: version "v2.1.0" invalid: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```

This PR creates a new subdir and module for v2, as documented in the "Major subdirectory" upgrade strategy on the golang module wiki: https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher
