### PR TITLE
Allow clients to remove the least recently used items from the cache

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -296,6 +296,14 @@ func (b *Bicache) Resume() error {
 	return nil
 }
 
+// RemoveLeastRecentlyUsed remove the last element from
+// the MRU cache in each shard.
+func (b *Bicache) RemoveLeastRecentlyUsed() {
+	for _, s := range b.shards {
+		s.evictFromMRUTail(1)
+	}
+}
+
 // getShard returns the shard index
 // using fnv-1 32 bit based hash-routing
 // (we can mask for a modulo since ShardCount

--- a/sll/sll.go
+++ b/sll/sll.go
@@ -110,7 +110,7 @@ func (ll *Sll) Copy() *Sll {
 }
 
 // HighScores takes an integer and returns the
-// respective number of *Nodes with the higest scores
+// respective number of *Nodes with the highest scores
 // sorted in ascending order.
 func (ll *Sll) HighScores(k int) NodeScoreList {
 	h := &MinHeap{}


### PR DESCRIPTION
I'm looking to use bicache with groupcache and would like to keep groupcaches ability to limit the size of the cache in bytes. I think adding the byte counting and eviction policy to bicache would need a decent amount of changes so giving the client the ability to evict on-demand will allow groupcache to manage the cache size.

Removing the least recently used item seems like the most logical policy at the moment and is already supported by bicache so this PR just exposes it to the client.