### PR TITLE
sll: Use atomic.LoadUint64 to make Len() thread-safe

### DIFF
--- a/sll/sll.go
+++ b/sll/sll.go
@@ -84,7 +84,7 @@ func (nsl NodeScoreList) Swap(i, j int) {
 
 // Len returns the count of nodes in the *Sll.
 func (ll *Sll) Len() uint {
-	return uint(ll.len)
+	return uint(atomic.LoadUint64(&ll.len))
 }
 
 // Head returns the head *Node.


### PR DESCRIPTION
Add a test that causes the race detector to report the following error. Fix it by using atomic.LoadUint64.
```
==================
WARNING: DATA RACE
Write at 0x00c000024b58 by goroutine 25:
  ??()
      -:0 +0x10215f7dc
  sync/atomic.AddUint64()
      <autogenerated>:1 +0x14
  github.com/jamiealquiza/bicache/v2/sll_test.TestRace.func1()
      bicache/sll/sll_test.go:414 +0xa4

Previous read at 0x00c000024b58 by goroutine 26:
  github.com/jamiealquiza/bicache/v2/sll.(*Sll).Len()
      bicache/sll/sll.go:87 +0xcc
  github.com/jamiealquiza/bicache/v2/sll_test.TestRace.func2()
      bicache/sll/sll_test.go:423 +0xc8

Goroutine 25 (running) created at:
  github.com/jamiealquiza/bicache/v2/sll_test.TestRace()
      bicache/sll/sll_test.go:411 +0x270
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/testing/testing.go:1742 +0x40

Goroutine 26 (finished) created at:
  github.com/jamiealquiza/bicache/v2/sll_test.TestRace()
      bicache/sll/sll_test.go:418 +0x34c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.4/libexec/src/testing/testing.go:1742 +0x40
==================
```