### PR TITLE
New(): Convert Config.AutoEvict to milliseconds

### DIFF
--- a/bicache.go
+++ b/bicache.go
@@ -159,7 +159,7 @@ func New(c *Config) (*Bicache, error) {
 	// if configured.
 	if c.AutoEvict > 0 {
 		cache.autoEvict = true
-		iter := time.Duration(c.AutoEvict)
+		iter := time.Duration(c.AutoEvict) * time.Millisecond
 		go bgAutoEvict(ctx, cache, iter, c)
 	}
 

--- a/bicache.go
+++ b/bicache.go
@@ -180,7 +180,7 @@ func (b *Bicache) Close() {
 func bgAutoEvict(ctx context.Context, b *Bicache, iter time.Duration, c *Config) {
 	ttlTachy := tachymeter.New(&tachymeter.Config{Size: c.ShardCount})
 	promoTachy := tachymeter.New(&tachymeter.Config{Size: c.ShardCount})
-	interval := time.NewTicker(time.Millisecond * iter)
+	interval := time.NewTicker(iter)
 	var evicted int
 	var start time.Time
 


### PR DESCRIPTION
This configuration option is documented as:

    The AutoEvict setting specifies an interval in milliseconds

The code converted from `uint` to `time.Duration`, which treats it as nanoseconds. Move the conversion from `bgAutoEvict` to `New()` so the `time.Duration` has the correct value everywhere in the code.