### PR TITLE
Fix race condition on `Get`

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -151,11 +151,12 @@ func (b *Bicache) Get(k string) interface{} {
 
 	if n, exists := s.cacheMap[k]; exists {
 		read := n.node.Read()
+		val := read.(*cacheData).v
 
 		s.RUnlock()
 		atomic.AddUint64(&s.counters.hits, 1)
 
-		return read.(*cacheData).v
+		return val
 	}
 
 	s.RUnlock()


### PR DESCRIPTION
Without the additional `defer` in this PR, `go test -race` would fail when `TestConcurrentReadsAndWrites` was run with `go test -race`:

```
=== RUN   TestConcurrentReadsAndWrites
==================
WARNING: DATA RACE
Write at 0x00c000092030 by goroutine 12:
  github.com/jamiealquiza/bicache/v2.(*Bicache).SetTTL()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods.go:123 +0x25c
  github.com/jamiealquiza/bicache/v2_test.TestConcurrentReadsAndWrites.func1()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods_test.go:543 +0xdc

Previous read at 0x00c000092030 by goroutine 37:
  github.com/jamiealquiza/bicache/v2.(*Bicache).Get()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods.go:158 +0x1e8
  github.com/jamiealquiza/bicache/v2_test.TestConcurrentReadsAndWrites.func2()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods_test.go:551 +0x80

Goroutine 12 (running) created at:
  github.com/jamiealquiza/bicache/v2_test.TestConcurrentReadsAndWrites()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods_test.go:540 +0x1ec
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1742 +0x40

Goroutine 37 (finished) created at:
  github.com/jamiealquiza/bicache/v2_test.TestConcurrentReadsAndWrites()
      /Users/ian.ferguson/git/jamiealquiza/bicache/methods_test.go:549 +0xf8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1742 +0x40
==================
    testing.go:1398: race detected during execution of test
--- FAIL: TestConcurrentReadsAndWrites (0.08s)

FAIL

Process finished with the exit code 1
```

this is due to the `return read.(*cacheData).v` access happening outside `s` RLock used to cover that read. 

this pull requerst moves that access inside the read lock, and the added test cases passes now